### PR TITLE
Update Kernel Patch - m8plus.md

### DIFF
--- a/manual/Kernel Patch - m8plus.md
+++ b/manual/Kernel Patch - m8plus.md
@@ -24,7 +24,7 @@ Choose the m8plus.ips patch file.
 
 ![Step 6](https://github.com/MakeMHz/xbox-hdmi/raw/master/manual/images/patch/m8plus_patch_6.png)
 
-Choose the m8plus_kernel.img
+Set 'Files of type:' from 'Most Common ROM Files' to 'All Files' and choose the m8plus_kernel.img
 
 ![Step 7](https://github.com/MakeMHz/xbox-hdmi/raw/master/manual/images/patch/m8plus_patch_7.png)
 


### PR DESCRIPTION
As seen in the #support channel on the discord server the step to change the 'file type', for the m8plus_kernel.img to show up, isn't clear to everyone and should be pointed out.